### PR TITLE
Fix compilation by adding annotation API and using release 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <swagger.core.version>2.2.22</swagger.core.version>
   </properties>
@@ -29,6 +28,14 @@
       <groupId>javax.json.bind</groupId>
       <artifactId>javax.json.bind-api</artifactId>
       <version>1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Anotações comuns como @Resource -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary
- configure compiler to use release 11
- add javax.annotation API dependency for @Resource

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b60f523fe8832583c901c125ccb2e3